### PR TITLE
Support for customized addresses

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,8 +23,12 @@ consul_install_webui: False
 
 consul_conf_datacenter: 'dc1'
 consul_conf_bootstrap: false
-consul_conf_bind_addr: "{{ ansible_default_ipv4.address }}"
-consul_conf_client_addr: "{{ ansible_default_ipv4.address }}"
+consul_conf_bind_addr: 0.0.0.0
+consul_conf_client_addr: 127.0.0.1
+consul_conf_addresses_dns: "{{ consul_conf_client_addr }}"
+consul_conf_addresses_http: "{{ ansible_default_ipv4.address }}"
+consul_conf_addresses_https: "{{ ansible_default_ipv4.address }}"
+consul_conf_addresses_rpc: "{{ consul_conf_client_addr }}"
 consul_conf_data_dir: "{{ consul_data_path }}"
 consul_conf_log_level: 'info'
 consul_conf_node_name: "{{ consul_install_mode }}-{{ ansible_hostname | regex_replace('\\.', '_') }}"

--- a/templates/00-defaults.json.j2
+++ b/templates/00-defaults.json.j2
@@ -8,6 +8,12 @@
 {% endif %}
   "bind_addr": "{{ consul_conf_bind_addr }}",
   "client_addr": "{{ consul_conf_client_addr }}",
+  "addresses": {
+    "dns": "{{ consul_conf_addresses_dns }}",
+    "http": "{{ consul_conf_addresses_http }}",
+    "https": "{{ consul_conf_addresses_https }}",
+    "rpc": "{{ consul_conf_addresses_rpc }}"
+  },
   "data_dir": "{{ consul_conf_data_dir }}",
   "log_level": "{{ consul_conf_log_level }}",
   "node_name": "{{ consul_conf_node_name }}",

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,4 @@
-consul_playbook_version: "0.2.0"
+consul_playbook_version: "0.3.0"
 
 # Packages per version, system and architecture
 consul_packages:


### PR DESCRIPTION
Add new element to configuration for customizing addresses used for binding DNS, HTTP/S and RPC ports. Switch back to default addresses as per Consul documentation, i.e. use 127.0.0.1 for client address and 0.0.0.0 (first private IP) for other binding.
